### PR TITLE
Fix the crash caused by the interface mismatch with the latest OpenMfxForBlender

### DIFF
--- a/src/plugins/houdini_utils.h
+++ b/src/plugins/houdini_utils.h
@@ -50,6 +50,31 @@ if (HAPI_RESULT_SUCCESS != res) { \
 } \
 if (HAPI_RESULT_SUCCESS != res) \
 
+#include <Windows.h>
+static void houdini_output_debug_printf(const char* strOutputString, ...)
+{
+    char strBuffer[4096] = { 0 };
+    va_list vlArgs;
+    va_start(vlArgs, strOutputString);
+
+    _vsnprintf_s(strBuffer, sizeof(strBuffer) - 1, sizeof(strBuffer) - 1, strOutputString, vlArgs);
+    va_end(vlArgs);
+    printf(strBuffer);
+    OutputDebugStringA(strBuffer);
+}
+
+#include <time.h>
+
+#define MFX_CLOCK_CONCAT_INDIRECT(x,y) x##y
+
+#define MFX_CLOCK_CONCAT(x,y) MFX_CLOCK_CONCAT_INDIRECT(x,y)
+
+#define MFX_CLOCK_BEGIN(action) clock_t MFX_CLOCK_CONCAT(before, action) = clock();
+
+#define MFX_CLOCK_END(action) clock_t MFX_CLOCK_CONCAT(difference, action) = clock() - MFX_CLOCK_CONCAT(before, action);\
+int MFX_CLOCK_CONCAT(msec, action) = MFX_CLOCK_CONCAT(difference, action) * 1000 / CLOCKS_PER_SEC;\
+houdini_output_debug_printf("%s time cost %d ms\n", #action, MFX_CLOCK_CONCAT(msec, action));
+
  // Utils
 
 inline int max(int a, int b) {

--- a/src/plugins/mfx_houdini_plugin.c
+++ b/src/plugins/mfx_houdini_plugin.c
@@ -280,7 +280,7 @@ static OfxStatus plugin_cook(PluginRuntime *runtime, OfxMeshEffectHandle meshEff
 	// Get input data
 	int input_point_count = 0, input_vertex_count = 0, input_face_count = 0;
 	MFX_CHECK(propertySuite->propGetInt(input_mesh_prop, kOfxMeshPropPointCount, 0, &input_point_count));
-	MFX_CHECK(propertySuite->propGetInt(input_mesh_prop, kOfxMeshAttribCornerPoint, 0, &input_vertex_count));
+	MFX_CHECK(propertySuite->propGetInt(input_mesh_prop, kOfxMeshPropCornerCount, 0, &input_vertex_count));
 	MFX_CHECK(propertySuite->propGetInt(input_mesh_prop, kOfxMeshPropFaceCount, 0, &input_face_count));
 
 	Attribute input_pos, input_vertpoint, input_facecounts;

--- a/src/plugins/mfx_houdini_plugin.c
+++ b/src/plugins/mfx_houdini_plugin.c
@@ -290,6 +290,8 @@ static OfxStatus plugin_cook(PluginRuntime *runtime, OfxMeshEffectHandle meshEff
 
 	printf("DEBUG: Found %d points in input mesh\n", input_point_count);
 
+	MFX_CLOCK_BEGIN(hruntime_feed_input_data);
+
 	hruntime_feed_input_data(hr,
 		                     input_pos, input_point_count,
 		                     input_vertpoint, input_vertex_count,
@@ -303,13 +305,20 @@ static OfxStatus plugin_cook(PluginRuntime *runtime, OfxMeshEffectHandle meshEff
 		hruntime_feed_vertex_attribute(hr, "uv", input_vertex_attr, input_vertex_count);
 	}
 
+	MFX_CLOCK_END(hruntime_feed_input_data);
+
+	MFX_CLOCK_BEGIN(hruntime_commit_geo);
 	hruntime_commit_geo(hr);
+	MFX_CLOCK_END(hruntime_commit_geo);
 
 	MFX_CHECK(meshEffectSuite->inputReleaseMesh(input_mesh));
 
 	// Get parameters
 	OfxParamSetHandle parameters;
 	OfxParamHandle param;
+
+	MFX_CLOCK_BEGIN(hruntime_get_parameter_name);
+
 	MFX_CHECK(meshEffectSuite->getParamSet(meshEffect, &parameters));
 
 	char name[MOD_HOUDINI_MAX_PARAMETER_NAME];
@@ -327,8 +336,11 @@ static OfxStatus plugin_cook(PluginRuntime *runtime, OfxMeshEffectHandle meshEff
 		}
 	}
 
+	MFX_CLOCK_END(hruntime_get_parameter_name);
+
 	// Core cook
 
+	MFX_CLOCK_BEGIN(hruntime_cook_asset);
 	if (false == hruntime_cook_asset(hr)) {
 		char* message = hruntime_get_cook_error(hr);
 		if (NULL != message) {
@@ -337,12 +349,18 @@ static OfxStatus plugin_cook(PluginRuntime *runtime, OfxMeshEffectHandle meshEff
 		}
 		return kOfxStatErrUnknown;
 	}
+	MFX_CLOCK_END(hruntime_cook_asset);
+
+	MFX_CLOCK_BEGIN(hruntime_fetch_sops);
 	if (false == hruntime_fetch_sops(hr)) {
 		return kOfxStatErrUnknown;
 	}
 
+	MFX_CLOCK_END(hruntime_fetch_sops);
+
 	OfxMeshHandle output_mesh;
 	OfxPropertySetHandle output_mesh_prop;
+	MFX_CLOCK_BEGIN(hruntime_consolidate_geo_counts);
 	MFX_CHECK(meshEffectSuite->inputGetMesh(output, time, &output_mesh, &output_mesh_prop));
 
 	// Consolidate geo counts
@@ -372,16 +390,21 @@ static OfxStatus plugin_cook(PluginRuntime *runtime, OfxMeshEffectHandle meshEff
 	MFX_CHECK2(getVertexAttribute(runtime, output_mesh, kOfxMeshAttribCornerPoint, &output_vertpoint));
 	MFX_CHECK2(getFaceAttribute(runtime, output_mesh, kOfxMeshAttribFaceSize, &output_facecounts));
 
+	MFX_CLOCK_END(hruntime_consolidate_geo_counts);
+
+	MFX_CLOCK_BEGIN(hruntime_fill_mesh);
 	// Fill data
 	hruntime_fill_mesh(hr,
-		               output_pos, output_point_count,
-		               output_vertpoint, output_vertex_count,
-		               output_facecounts, output_face_count);
+		output_pos, output_point_count,
+		output_vertpoint, output_vertex_count,
+		output_facecounts, output_face_count);
 
 	if (has_uv) {
 		MFX_CHECK2(getVertexAttribute(runtime, output_mesh, "uv0", &output_uv));
 		hruntime_fill_vertex_attribute(hr, output_uv, "uv");
 	}
+
+	MFX_CLOCK_END(hruntime_fill_mesh);
 
 	MFX_CHECK(meshEffectSuite->inputReleaseMesh(output_mesh));
 

--- a/src/util/intern/plugin_support.c
+++ b/src/util/intern/plugin_support.c
@@ -85,7 +85,7 @@ OfxStatus getPointAttribute(PluginRuntime* runtime, OfxMeshHandle mesh, const ch
 
 OfxStatus getVertexAttribute(PluginRuntime* runtime, OfxMeshHandle mesh, const char *name, Attribute *attr)
 {
-  return getAttribute(runtime, mesh, kOfxMeshAttribVertex, name, attr);
+  return getAttribute(runtime, mesh, kOfxMeshAttribCorner, name, attr);
 }
 
 OfxStatus getFaceAttribute(PluginRuntime* runtime, OfxMeshHandle mesh, const char *name, Attribute *attr)


### PR DESCRIPTION
Fix the crash caused by the interface mismatch with the latest OpenMfxForBlender